### PR TITLE
Allow JIT optimization.

### DIFF
--- a/sprites.js
+++ b/sprites.js
@@ -582,9 +582,13 @@ function memcpyU8(source, destination, readloc, writeloc, writelength/*, thing*/
   if(readloc == null) readloc = 0;
   if(writeloc == null) writeloc = 0;
   if(writelength == null) writelength = max(0, min(source.length, destination.length));
-  while(writelength--)
-  // while(--writelength)
-    destination[writeloc++] = source[readloc++];
+
+  var lwritelength = writelength + 0; // Allow JIT integer optimization (Firefox needs this)
+  var lwriteloc = writeloc + 0;
+  var lreadloc = readloc + 0;
+  while(lwritelength--)
+  // while(--lwritelength)
+    destination[lwriteloc++] = source[lreadloc++];
 }
 
 // Somewhat cross-platform way to make a canvas' 2d context not smooth pixels


### PR DESCRIPTION
Firefox speeds up a lot with this. Fixes the speed part of #19 -- but it's still too slow, probably has to do with Firefox's timing apis. (Firefox no longer eats an entire core after this.)

The reason this works is that the JIT no longer has to run a check every time it loops, as "+0" marks the value as an integer.
