### PR TITLE
Added logic to unset sound.used if resume is false.

### DIFF
--- a/sounds.js
+++ b/sounds.js
@@ -85,6 +85,10 @@ function playTheme(name_raw, resume, loop) {
   } 
   
   // If it's only used once, add the event listener to resume theme
+  if(!resume) {
+    sound.used = false;
+  }
+
   if(sound.used == 1) sound.addEventListener("ended", playTheme);
   
   return sound;


### PR DESCRIPTION
Patched JS issues, this would be thrown approximately 5 seconds after World Clear theme runs:

Unknown sound: '[object Event]' 
Uncaught TypeError: Cannot set property 'loop' of undefined 

sound.used was still running even though, resume was set to false. Added a small bit of logic that resets sound.used, if resume is false so that if(sound.used == 1) sound.addEventListener("ended", playTheme); is not run after World Clear plays. Tested on multiple other levels and seems to still work as expected.
