### PR TITLE
Fixed horizontal pipe issue, where Mario can't get into 1-2 pipe to underworld

### DIFF
--- a/maps.js
+++ b/maps.js
@@ -503,12 +503,8 @@ function walkToPipe() {
 
   var hasPipingStarted = false;
   var move = setInterval(function() {
-    if(mario.piping && !hasPipingStarted) {
+    if(mario.piping) {
       // We have started piping
-      hasPipingStarted = true;
-    }
-    else if ( !mario.piping && hasPipingStarted ) {
-      // piping has finished
       if(sounds[0]) sounds[0].pause();
       nokeys = mario.keys.run = notime = false;
       clearInterval(move);
@@ -539,7 +535,6 @@ function intoPipeVert(me, pipe, transport) {
   }, timer);
 }
 function intoPipeHoriz(me, pipe, transport) {
-  if(!me.keys.run || !(me.resting || map.underwater)) return;
   pipePreparations(me);
   switchContainers(me, characters, scenery);
   unpause();


### PR DESCRIPTION
I think this is the issue:

if(!me.keys.run || !(me.resting || map.underwater)) return;

I'm not sure exactly what this was needed for. When I removed it, it didn't seem to cause issues in 1-2 or 2-2. And once I removed it the issue with Mario not being able to enter the pipe stopped.
