### PR TITLE
Put height limit on how high bloopers can go on the screen in level 2-2

### DIFF
--- a/things.js
+++ b/things.js
@@ -966,6 +966,11 @@ function moveBlooper(me) {
     case 63: squeezeBlooper(me); break;
     default: ++me.counter; break;
   }
+
+  if(me.top < unitsizet16 + 10) {
+    squeezeBlooper(me);
+  }
+
   if(me.squeeze) me.yvel = max(me.yvel + .021, .7); // going down
   else me.yvel = min(me.yvel - .035, -.7); // going up
   shiftVert(me, me.yvel, true);


### PR DESCRIPTION
The bloopers are going to the top of the screen, this makes them stay in the water.
